### PR TITLE
fix: match_parameter function when result's parameter is nil.

### DIFF
--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -26,6 +26,10 @@ local match_parameter = function(result)
     return result
   end
 
+  if signature.parameters == nil then
+    return result
+  end
+
   if #signature.parameters < 2 or activeParameter + 1 > #signature.parameters then
     return result
   end


### PR DESCRIPTION
Fix the https://github.com/ray-x/lsp_signature.nvim/issues/4

Please check it out.

Thank you.