### PR TITLE
fix: helper.match_parameter function when nextParameter is nil.

### DIFF
--- a/lua/lsp_signature_helper.lua
+++ b/lua/lsp_signature_helper.lua
@@ -22,6 +22,10 @@ helper.match_parameter = function(result)
 
   local nextParameter = signature.parameters[activeParameter + 1]
 
+  if nextParameter == nil then
+    return result
+  end
+
   local label = signature.label
   if type(nextParameter.label) == "table" then -- label = {2, 4} c style
     local range = nextParameter.label


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1021047/116334297-85ebe980-a807-11eb-9d74-d039d8220403.png)


Maybe it's pyright issue.
lsp_signature.nvim should cover some cases.

Please check it out.

Thank you.