### PR TITLE
Added `extra_trigger_chars` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Thanks [@Gabriel Sanches](https://github.com/gbrlsnchs) for the PR
   handler_opts = {
     border = "shadow"   -- double, single, shadow, none
   },
+  extra_trigger_chars = {} -- Array of extra characters that will trigger signature completion, e.g., {"(", ","}
   -- deprecate !!
   -- decorator = {"`", "`"}  -- this is no longer needed as nvim give me a handler and it allow me to highlight active parameter in floating_window
 

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -28,7 +28,8 @@ _LSP_SIG_CFG = {
   hi_parameter = "Search",
   handler_opts = {border = "single"},
   use_lspsaga = false,
-  debug = false
+  debug = false,
+  extra_trigger_chars = {}
   -- decorator = {"`", "`"} -- set to nil if using guihua.lua
 }
 
@@ -245,6 +246,9 @@ local signature = function()
       if value.server_capabilities.signatureHelpProvider.retriggerCharacters ~= nil then
         vim.list_extend(triggered_chars,
                         value.server_capabilities.signatureHelpProvider.retriggerCharacters)
+      end
+      if _LSP_SIG_CFG.extra_trigger_chars ~= nil then
+        vim.list_extend(triggered_chars, _LSP_SIG_CFG.extra_trigger_chars)
       end
     elseif value.resolved_capabilities ~= nil
         and value.resolved_capabilities.signature_help_trigger_characters ~= nil then

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -29,7 +29,7 @@ _LSP_SIG_CFG = {
   handler_opts = {border = "single"},
   use_lspsaga = false,
   debug = false,
-  extra_trigger_chars = {}
+  extra_trigger_chars = {} -- Array of extra characters that will trigger signature completion, e.g., {"(", ","}
   -- decorator = {"`", "`"} -- set to nil if using guihua.lua
 }
 


### PR DESCRIPTION
Omnsiharp-roslyn has useless characters set as the trigger characters
for signature help, namely `.`, `?` and `[` (see this issue for more
info: https://github.com/OmniSharp/omnisharp-roslyn/issues/1119).

I added the `extra_trigger_chars` option so I could set '(' and ','
as additional triggers when using omnisharp, and I figured these
modifications could be useful for other servers as well.