### PR TITLE
Correction for nil input in helper.fallback

### DIFF
--- a/lua/lsp_signature_helper.lua
+++ b/lua/lsp_signature_helper.lua
@@ -43,6 +43,9 @@ helper.fallback = function(trigger_chars)
   local line = vim.api.nvim_get_current_line()
   line = line:sub(1, r[2])
   local activeParameter = 0
+  if type(trigger_chars)~="table" then
+    return
+  end
   if not vim.tbl_contains(trigger_chars, "(") then
     return
   end
@@ -87,6 +90,9 @@ helper.match_parameter = function(result, config)
   -- if #signature.parameters < 2 or activeParameter + 1 > #signature.parameters then
   --   return result, ""
   -- end
+  if activeParameter == nil then
+    return result, ""
+  end
 
   local nextParameter = signature.parameters[activeParameter + 1]
 


### PR DESCRIPTION
In a certain situation, an error is raised when calling `vim.lsp.buf.signature_help()`:

``` vim
Error executing vim.schedule lua callback: vim/shared.lua:183: t: expected table, got nil
stack traceback:
        vim/shared.lua:183: in function 'tbl_contains'
        ...er/start/lsp_signature.nvim/lua/lsp_signature_helper.lua:46: in function 'fallback'
        ...er/start/lsp_signature.nvim/lua/lsp_signature_helper.lua:78: in function 'match_parameter'
        ...ck/packer/start/lsp_signature.nvim/lua/lsp_signature.lua:130: in function 'handler'
        ...neovim/HEAD-24e0c16_2/share/nvim/runtime/lua/vim/lsp.lua:897: in function 'cb'
        vim.lua:277: in function <vim.lua:277>
```


For example with this source code (using jedi-language-server as the only attached LSP) with the cursor on the last `)`

``` py
import numpy as np

np.empty(1, order="F")
```


The error seems to come from fallback function, which in the first `if` statement calls `vim.tbl_contains`, which expects a `table` type, which in this special situation, `config.triggered_chars` is `nil`. The proposed change to `helper.fallback` returns nothing if `trigger_chars` is `nil`. It also adds a check for `activeParameter` in match parameter since the previous modification can set this variable to `nil`.
