### PR TITLE
Fixed errors shown when `lines` is nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Thanks [@Gabriel Sanches](https://github.com/gbrlsnchs) for the PR
   handler_opts = {
     border = "shadow"   -- double, single, shadow, none
   },
+  extra_trigger_chars = {} -- Array of extra characters that will trigger signature completion, e.g., {"(", ","}
   -- deprecate !!
   -- decorator = {"`", "`"}  -- this is no longer needed as nvim give me a handler and it allow me to highlight active parameter in floating_window
 

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -28,7 +28,8 @@ _LSP_SIG_CFG = {
   hi_parameter = "Search",
   handler_opts = {border = "single"},
   use_lspsaga = false,
-  debug = false
+  debug = false,
+  extra_trigger_chars = {}
   -- decorator = {"`", "`"} -- set to nil if using guihua.lua
 }
 
@@ -245,6 +246,9 @@ local signature = function()
       if value.server_capabilities.signatureHelpProvider.retriggerCharacters ~= nil then
         vim.list_extend(triggered_chars,
                         value.server_capabilities.signatureHelpProvider.retriggerCharacters)
+      end
+      if _LSP_SIG_CFG.extra_trigger_chars ~= nil then
+        vim.list_extend(triggered_chars, _LSP_SIG_CFG.extra_trigger_chars)
       end
     elseif value.resolved_capabilities ~= nil
         and value.resolved_capabilities.signature_help_trigger_characters ~= nil then

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -128,6 +128,10 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     local ft = vim.api.nvim_buf_get_option(bufnr, "ft")
     local lines = vim.lsp.util.convert_signature_help_to_markdown_lines(result, ft)
 
+    if lines == nil then
+        return
+    end
+
     local offset = 3
     if #result.signatures > 1 and result.activeSignature ~= nil then
       for index, sig in ipairs(result.signatures) do
@@ -144,11 +148,13 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     end
     if vim.fn.mode() == 'i' or vim.fn.mode() == 'ic' then
       -- truncate the doc?
-      if #lines > doc_num + 1 then
-        if doc_num == 0 then
-          lines = vim.list_slice(lines, 1, offset + 1)
-        else
-          lines = vim.list_slice(lines, 1, doc_num + offset + 1)
+      if lines ~= nil then
+        if #lines > doc_num + 1 then
+          if doc_num == 0 then
+            lines = vim.list_slice(lines, 1, offset + 1)
+          else
+            lines = vim.list_slice(lines, 1, doc_num + offset + 1)
+          end
         end
       end
     end

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -29,7 +29,7 @@ _LSP_SIG_CFG = {
   handler_opts = {border = "single"},
   use_lspsaga = false,
   debug = false,
-  extra_trigger_chars = {}
+  extra_trigger_chars = {} -- Array of extra characters that will trigger signature completion, e.g., {"(", ","}
   -- decorator = {"`", "`"} -- set to nil if using guihua.lua
 }
 


### PR DESCRIPTION
Sometimes, when the signature is triggered by mistake outside of functions, I was getting some errors because the `lines` variable is `nil`. These checks seem to make the errors go away.