### PR TITLE
Enhancement: add padding around signature when border is none

### DIFF
--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -265,6 +265,13 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     -- fix pos case
     log('win config', config)
     local new_line = helper.is_new_line()
+    
+    if config.border == "none" then
+      for lineIndex = 1, #lines do
+        lines[lineIndex] = ' ' .. lines[lineIndex] .. ' '
+      end
+      config.offset_x = config.offset_x - 0.5
+    end
 
     if _LSP_SIG_CFG.fix_pos and _LSP_SIG_CFG.bufnr and _LSP_SIG_CFG.winnr then
       if api.nvim_win_is_valid(_LSP_SIG_CFG.winnr) and _LSP_SIG_CFG.label == label and not new_line then
@@ -298,9 +305,15 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     local hi = _LSP_SIG_CFG.hi_parameter
     log("extmark", s, l)
     if s and l and s > 0 then
+      if config.border ~= "none" then
+        s = s - 1
+      else
+        l = l + 1
+      end
       _LSP_SIG_CFG.markid = vim.api.nvim_buf_set_extmark(_LSP_SIG_CFG.bufnr, _LSP_SIG_CFG.ns, 0,
-                                                         s - 1,
+                                                         s,
                                                          {end_line = 0, end_col = l, hl_group = hi})
+
     else
       print("failed get highlight parameter", s, l)
     end

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -29,6 +29,7 @@ _LSP_SIG_CFG = {
   hint_scheme = "String",
   hi_parameter = "Search",
   handler_opts = {border = "single"},
+  padding = '', -- character to pad on left and right of signature
   use_lspsaga = false,
   debug = false,
   extra_trigger_chars = {}, -- Array of extra characters that will trigger signature completion, e.g., {"(", ","}
@@ -266,11 +267,11 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     log('win config', config)
     local new_line = helper.is_new_line()
     
-    if config.border == "none" then
+    if _LSP_SIG_CFG.padding ~= "" then
       for lineIndex = 1, #lines do
-        lines[lineIndex] = ' ' .. lines[lineIndex] .. ' '
+        lines[lineIndex] = _LSP_SIG_CFG.padding .. lines[lineIndex] .. _LSP_SIG_CFG.padding
       end
-      config.offset_x = config.offset_x - 0.5
+      config.offset_x = config.offset_x - #_LSP_SIG_CFG.padding
     end
 
     if _LSP_SIG_CFG.fix_pos and _LSP_SIG_CFG.bufnr and _LSP_SIG_CFG.winnr then
@@ -305,10 +306,11 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     local hi = _LSP_SIG_CFG.hi_parameter
     log("extmark", s, l)
     if s and l and s > 0 then
-      if config.border ~= "none" then
+      if _LSP_SIG_CFG.padding == "" then
         s = s - 1
       else
-        l = l + 1
+        s = s - 1 + #_LSP_SIG_CFG.padding
+        l = l + #_LSP_SIG_CFG.padding
       end
       _LSP_SIG_CFG.markid = vim.api.nvim_buf_set_extmark(_LSP_SIG_CFG.bufnr, _LSP_SIG_CFG.ns, 0,
                                                          s,


### PR DESCRIPTION
Hi! Sorry to bother you again. I would like to use this plugin without border (using setting 'none'), but it's quite hard to see sometimes. I could use a different highlight, but I like the signature to not be too distracting. I like how jedi-vim adds a single character padding left and right:
![image](https://user-images.githubusercontent.com/70747/128146632-734a5ac6-3f7e-4477-af60-cc640250cae8.png)

I've tried adding pad_left/pad_right to the config dictionary of the `open_floating_preview`, but I couldn't get it to show up. So now I've added 'spaces' to the lines. It works for me, but I guess it would be nice to have a configurable option? I'm not sure how to add that, I don't have a lot of experience in lua.

Before:
<img width="307" alt="Screenshot 2021-08-04 at 10 39 55" src="https://user-images.githubusercontent.com/70747/128150356-f6a829ef-433f-4568-a34a-41a98ff0f422.png">

After:
<img width="313" alt="Screenshot 2021-08-04 at 10 39 13" src="https://user-images.githubusercontent.com/70747/128150377-61ae9949-c73e-4c16-942d-8f122258d67c.png">
