### PR TITLE
Improvements to signature help (especially when fix_pos=true)

### DIFF
--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -132,8 +132,8 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     end
   end
   if not (result and result.signatures and result.signatures[1]) then
-    log("no result?", result)
-    if helper.is_new_line() then
+    -- only close if this client opened the signature
+    if _LSP_SIG_CFG.client_id == client_id then
       helper.cleanup(true)
       -- need to close floating window and virtual text (if they are active)
     end
@@ -301,11 +301,13 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
         _LSP_SIG_CFG.bufnr, _LSP_SIG_CFG.winnr = vim.lsp.util.open_floating_preview(lines, syntax,
                                                                                     config)
         _LSP_SIG_CFG.label = label
+        _LSP_SIG_CFG.client_id = client_id
       end
     else
       _LSP_SIG_CFG.bufnr, _LSP_SIG_CFG.winnr = vim.lsp.util.open_floating_preview(lines, syntax,
                                                                                   config)
       _LSP_SIG_CFG.label = label
+      _LSP_SIG_CFG.client_id = client_id
     end
 
     local sig = result.signatures

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -285,9 +285,6 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     if not config.trigger_from_lsp_sig then
       config.close_events = close_events
     end
-    if force_redraw then
-      config.close_events = close_events
-    end
     if result.signatures[activeSignature].parameters == nil
         or #result.signatures[activeSignature].parameters == 0 then
     if force_redraw and _LSP_SIG_CFG.fix_pos == false then

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -317,6 +317,10 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
         or result.activeParameter + 1 == #sig[activeSignature].parameters then
       log("last para", close_events)
       vim.lsp.util.close_preview_autocmd(close_events, _LSP_SIG_CFG.winnr)
+      if _LSP_SIG_CFG.fix_pos == false then
+        -- log("last para", close_events)
+        vim.lsp.util.close_preview_autocmd(close_events, _LSP_SIG_CFG.winnr)
+      end
       -- elseif _LSP_SIG_CFG.fix_pos then
       --   log("should not close")
       --   -- vim.lsp.util.close_preview_autocmd(ce, _LSP_SIG_CFG.winnr)

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -285,10 +285,15 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     if not config.trigger_from_lsp_sig then
       config.close_events = close_events
     end
-    if result.signatures[activeSignature].parameters == nil
-        or #result.signatures[activeSignature].parameters == 0 then
     if force_redraw and _LSP_SIG_CFG.fix_pos == false then
       config.close_events = close_events
+    end
+    if result.signatures[activeSignature].parameters == nil
+        or #result.signatures[activeSignature].parameters == 0 then
+      -- let LSP decide to close when fix_pos is false
+      if _LSP_SIG_CFG.fix_pos == false then
+        config.close_events = close_events
+      end
     end
     config.zindex = _LSP_SIG_CFG.zindex
     -- fix pos case

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -517,6 +517,8 @@ local show_after_delay = function(require_change)
       return
     elseif require_change == false then
       signature()
+      timer:stop()
+      timer:close()
     end
   end))
 end

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -278,6 +278,7 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
     end
     if result.signatures[activeSignature].parameters == nil
         or #result.signatures[activeSignature].parameters == 0 then
+    if force_redraw and _LSP_SIG_CFG.fix_pos == false then
       config.close_events = close_events
     end
     config.zindex = _LSP_SIG_CFG.zindex

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -180,13 +180,11 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
         if index ~= activeSignature then
           table.insert(lines, offset, sig.label)
           offset = offset + 1
-
-          log("after insert", offset, lines)
         end
       end
-      -- log("after insert", lines)
     end
 
+    log("md lines", lines)
     local label = result.signatures[1].label
     if #result.signatures > 1 then
       label = result.signatures[activeSignature].label

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -204,12 +204,24 @@ local function signature_handler(err, method, result, client_id, bufnr, config)
       log("md lines remove empty", lines)
     end
 
+  local pos = api.nvim_win_get_cursor(0)
+  local line = api.nvim_get_current_line()
+  local line_to_cursor = line:sub(1, pos[2])
+
     if config.triggered_chars and vim.tbl_contains(config.triggered_chars, '(') then
-      woff = label:find('(', 1, true)
-      if woff then
+      woff = line_to_cursor:find("%([^%(]*$")
+      local sig_woff = label:find("%([^%(]*$")
+      if woff and sig_woff then
+        local function_name = label:sub(1, sig_woff - 1)
+        local function_on_line = line_to_cursor:match('.*' .. function_name)
+        if function_on_line then
+          woff = #line_to_cursor - #function_on_line + #function_name
+        else
+          woff = sig_woff + (#line_to_cursor - woff)
+        end
         woff = -woff
       else
-        woff = -3
+        woff = 3
       end
     end
 

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -502,19 +502,18 @@ function M.on_InsertLeave()
   manager.insertLeave = true
 end
 
-local show_after_delay = function(require_change)
+local show_after_delay = function(require_change, delay)
   local timer = vim.loop.new_timer()
-  timer:start(100, 100, vim.schedule_wrap(function()
+  timer:start(delay, 100, vim.schedule_wrap(function()
     local l_changedTick = api.nvim_buf_get_changedtick(0)
     -- closing timer if leaving insert mode
-    if l_changedTick ~= manager.changedTick then
-      manager.changedTick = l_changedTick
-      signature()
-    elseif manager.insertLeave == true and timer:is_closing() == false then
+    if manager.insertLeave == true and timer:is_closing() == false then
       timer:stop()
       timer:close()
       vim.api.nvim_buf_clear_namespace(0, _VT_NS, 0, -1)
-      return
+    elseif l_changedTick ~= manager.changedTick then
+      manager.changedTick = l_changedTick
+      signature()
     elseif require_change == false then
       signature()
       timer:stop()
@@ -527,10 +526,11 @@ function M.on_InsertEnter()
   log("insert enter")
   -- show signature immediately upon entering insert mode
   if manager.insertLeave == true then
-    show_after_delay(false)
+    show_after_delay(false, 0)
+  else
+    show_after_delay(true, 100)
   end
   manager.init()
-  show_after_delay(true)
 end
 
 -- handle completion confirmation and dismiss hover popup


### PR DESCRIPTION
Hi,

These are quite some significant changes to make the signature help pop-up more reliably. Also improves the positioning of the signature help.

Improvements:
- When entering insert mode always show signature help when available
- When possible, request the signature at the nearest trigger character, this improves reliability. For example, when entering insert mode inside a function call, but not next to a trigger character, the signature will now be shown.
- Make the LSP responsible to close the signature help (thus when none are returned and fix_pos==true)
- When the LSP returns `<function_name>(...)` also use `function_name` to position the signature help more correctly. This is useful if there are more signatures on a single line.

Most of these improvements have only been tested during my main development work. Where I have `fix_pos==true`. Testing is needed with `fix_pos==false`. 