### PR TITLE
Map toggle_key in on_attach() instead of setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ local example_setup = {
       handler_opts = {
         border = "single"
       }
-    })
+    }, bufnr)
     ...
   end,
   ...
@@ -172,7 +172,7 @@ Or:
   toggle_key = nil -- toggle signature on and off in insert mode,  e.g. toggle_key = '<M-x>'
 }
 
-require'lsp_signature'.on_attach(cfg)
+require'lsp_signature'.on_attach(cfg, bufnr) -- no need to specify bufnr if you don't use toggle_key
 ```
 Note: navigator.lua no longer support auto setup for lsp_signature as the setup options is getting more complicated now
 

--- a/lua/lsp_signature.lua
+++ b/lua/lsp_signature.lua
@@ -519,7 +519,9 @@ function M.on_CompleteDone()
   end
 end
 
-M.on_attach = function(cfg)
+M.on_attach = function(cfg, bufnr)
+  bufnr = bufnr or 0
+
   api.nvim_command("augroup Signature")
   api.nvim_command("autocmd! * <buffer>")
   api.nvim_command("autocmd InsertEnter <buffer> lua require'lsp_signature'.on_InsertEnter()")
@@ -546,6 +548,11 @@ M.on_attach = function(cfg)
                                    _LSP_SIG_CFG.shadow_blend + 20, _LSP_SIG_CFG.shadow_guibg)
   vim.cmd(shadow_cmd)
 
+  if _LSP_SIG_CFG.toggle_key then
+    vim.api.nvim_buf_set_keymap(bufnr, 'i', _LSP_SIG_CFG.toggle_key,
+                                [[<cmd>lua require('lsp_signature').toggle_float_win()<CR>]],
+                                {silent = true, noremap = true})
+  end
 end
 
 M.toggle_float_win = function()
@@ -584,22 +591,16 @@ M.setup = function(cfg)
   vim.lsp.start_client = function(lsp_config)
     if lsp_config.on_attach == nil then
       lsp_config.on_attach = function(client, bufnr)
-        M.on_attach(cfg)
+        M.on_attach(cfg, bufnr)
       end
     else
       local _on_attach = lsp_config.on_attach
       lsp_config.on_attach = function(client, bufnr)
-        M.on_attach(cfg)
+        M.on_attach(cfg, bufnr)
         _on_attach(client, bufnr)
       end
     end
     return _start_client(lsp_config)
-  end
-
-  if cfg.toggle_key then
-    vim.api.nvim_set_keymap('i', cfg.toggle_key,
-                            [[<cmd>lua require('lsp_signature').toggle_float_win()<CR>]],
-                            {silent = true, noremap = true})
   end
 end
 


### PR DESCRIPTION
This allows specifying `toggle_key` in `on_attach`, and only maps `toggle_key` in buffers where LSP is attached.