### PR TITLE
fix lsp sumneko_lua  crach

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Or:
 }
 
 -- recommanded:
-require'lsp_signature'.setup(cfg) -- no need to specify bufnr if you don't use toggle_key
+require'lsp_signature'.setup({cfg}) -- no need to specify bufnr if you don't use toggle_key
 
 -- You can also do this inside lsp on_attach
 -- note: on_attach deprecated


### PR DESCRIPTION
I don't know why I should add `{}` to the table to avoid `sumneko_lua` crash
```lua
require'lsp_signature'.setup(cfg)

==>
require'lsp_signature'.setup({cfg})

```