### PR TITLE
fix bugs that not show no parameter function signature.

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -203,12 +203,10 @@ local signature_handler = helper.mk_handler(function(err, result, ctx, config)
       local sig = result.signatures[i]
       -- hack for lua
       local actPar = sig.activeParameter or result.activeParameter or 0
-      if actPar + 1 > math.max(#(sig.parameters or {}), 1) then
-        log("hack for lua")
-        table.remove(result.signatures, i)
-        if i <= activeSignature and activeSignature > 1 then
-          activeSignature = activeSignature - 1
-        end
+      if actPar > 0 && actPar + 1 > #(sig.parameters or {}) then
+        log("invalid lsp response or no parameters")
+        -- reset active parameter to last parameter
+        sig.activeParameter = #(sig.parameters or {})
       end
     end
   end

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -203,7 +203,7 @@ local signature_handler = helper.mk_handler(function(err, result, ctx, config)
       local sig = result.signatures[i]
       -- hack for lua
       local actPar = sig.activeParameter or result.activeParameter or 0
-      if actPar + 1 > #(sig.parameters or {}) then
+      if actPar + 1 > math.max(#(sig.parameters or {}), 1) then
         log("hack for lua")
         table.remove(result.signatures, i)
         if i <= activeSignature and activeSignature > 1 then

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -204,7 +204,7 @@ local signature_handler = helper.mk_handler(function(err, result, ctx, config)
       -- hack for lua
       local actPar = sig.activeParameter or result.activeParameter or 0
       if actPar > 0 && actPar + 1 > #(sig.parameters or {}) then
-        log("invalid lsp response or no parameters")
+        log("invalid lsp response, active parameter out of boundary")
         -- reset active parameter to last parameter
         sig.activeParameter = #(sig.parameters or {})
       end

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -203,7 +203,7 @@ local signature_handler = helper.mk_handler(function(err, result, ctx, config)
       local sig = result.signatures[i]
       -- hack for lua
       local actPar = sig.activeParameter or result.activeParameter or 0
-      if actPar > 0 && actPar + 1 > #(sig.parameters or {}) then
+      if actPar > 0 and actPar + 1 > #(sig.parameters or {}) then
         log("invalid lsp response, active parameter out of boundary")
         -- reset active parameter to last parameter
         sig.activeParameter = #(sig.parameters or {})


### PR DESCRIPTION
when there is a no parameter signature, it's be filtered by mistake.
clangd 11.0
int a();
int a(int x);
int a(int x, int y);
int main() {
  a( // only show a(int x) and a(int x, int y)
}