### PR TITLE
use only the first filetype when it is a multi-filetype

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -254,7 +254,14 @@ local signature_handler = helper.mk_handler(function(err, result, ctx, config)
   local lines = {}
   local off_y = 0
   local ft = vim.api.nvim_buf_get_option(bufnr, "ft")
+
   ft = helper.ft2md(ft)
+  -- handles multiple file type, we should just take the first filetype
+  -- find the first file type and substring until the .
+  local dot_index = string.find(ft, ".")
+  if dot_index ~= nil then
+      ft = string.sub(ft, 0, dot_index)
+  end
 
   lines = vim.lsp.util.convert_signature_help_to_markdown_lines(result, ft)
 


### PR DESCRIPTION
Initially created this as an issue but as I dug deeper, I thought I could fix it instead.

---- Issue
![Screenshot 2022-02-15 at 4 24 00 PM](https://user-images.githubusercontent.com/197371/154022525-150591fd-db5a-4888-a24c-1568e23b47cb.png)
![Screenshot 2022-02-15 at 4 29 07 PM](https://user-images.githubusercontent.com/197371/154022636-ab3a9d49-e22a-44ab-90bb-1a9b7fdec3bc.png)

Did a couple of test with this. 

1. I change the filetype from my multi-filetype to just plain haxe, and everything works.
2. Removing the comment from the function definition, also fixes it.

Turns out if the file type is recognized, i.e. just haxe, the first line will not be render, but because I use a multi-filetype for my files, the rendering of the first line breaks the highlighter.

----
Solutions

Initially I investigated whether I can continue to show the filetype, but instead figure out which line to highlight. After  digging the code base for an hour or so, I couldn't find a good way to handle it without making the code really messy.

I also realised that the function `ft2md` seems to be an attempt to get around this for javascript/jsx files, which is one of the more common multi-type. Seeing this solution already exists, I generalised the solution to always take the first filetype of any file.

This should fix most of the cases. Any suggestion is welcomed. I'm not a experienced plugin creator, so if there is a better solution, feel free to change and update 😄. I just wanted it to work.

