### PR TITLE
fix multi-filetype not splitting properly

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -258,9 +258,9 @@ local signature_handler = helper.mk_handler(function(err, result, ctx, config)
   ft = helper.ft2md(ft)
   -- handles multiple file type, we should just take the first filetype
   -- find the first file type and substring until the .
-  local dot_index = string.find(ft, ".")
+  local dot_index = string.find(ft, "%.")
   if dot_index ~= nil then
-      ft = string.sub(ft, 0, dot_index)
+      ft = string.sub(ft, 0, dot_index-1)
   end
 
   lines = vim.lsp.util.convert_signature_help_to_markdown_lines(result, ft)


### PR DESCRIPTION
Sorry for the previous commit as I am not familiar with lua's string api, and I am not sure how the previous case works for me.

This should really split the filetype properly