### PR TITLE
Add auto_display config option

### DIFF
--- a/doc/lsp_signature.txt
+++ b/doc/lsp_signature.txt
@@ -127,6 +127,7 @@ FULL CONFIGURATION (WITH DEFAULT VALUES) *lsp_signature-full_configuration_(with
       },
       always_trigger = false, -- sometime show signature on new line or in middle of parameter can be confusing, set it to false for #58
       auto_close_after = nil, -- autoclose signature float win after x sec, disabled if nil.
+      auto_display = true, -- display lsp signature automatically
       extra_trigger_chars = {}, -- Array of extra characters that will trigger signature completion, e.g., {"(", ","}
       zindex = 200, -- by default it will be on top of all floating windows, set to <= 50 send it to bottom
       padding = '', -- character to pad on left and right of signature can be ' ', or '|'  etc

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -45,6 +45,7 @@ _LSP_SIG_CFG = {
   -- set this to true if you the triggered_chars failed to work
   -- this will allow lsp server decide show signature or not
   auto_close_after = nil, -- autoclose signature after x sec, disabled if nil.
+  auto_display = true, -- display lsp signature automatically
   debug = false,
   log_path = path_join(vim.fn.stdpath("cache"), "lsp_signature.log"), -- log dir when debug is no
   verbose = false, -- debug show code line number
@@ -466,7 +467,7 @@ local signature = function()
     return
   end
 
-  if triggered then
+  if triggered and _LSP_SIG_CFG.auto_display then
     -- overwrite signature help here to disable "no signature help" message
     local params = vim.lsp.util.make_position_params()
     params.position.character = trigger_position


### PR DESCRIPTION
This option adds a configuration setting to not automatically display
the signature.  The signature can still be triggered manually with
toggle_key.