### PR TITLE
ignore signature results for other buffers

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -186,6 +186,10 @@ local signature_handler = function(err, result, ctx, config)
 
     return
   end
+  if api.nvim_get_current_buf() ~= bufnr then
+    log("ignore outdated signature result")
+    return
+  end
 
   if config.trigger_from_next_sig then
     log("trigger from next sig", config.activeSignature)

--- a/tests/signature_spec.lua
+++ b/tests/signature_spec.lua
@@ -261,7 +261,7 @@ describe("should show signature ", function()
   end)
 
   it("should show signature Date golang", function()
-    local ctx = { method = "textDocument/signatureHelp", client_id = 1, bufnr = 0 }
+    local ctx = { method = "textDocument/signatureHelp", client_id = 1, bufnr = vim.api.nvim_get_current_buf() }
     -- local lines, s, l = signature.signature_handler(nil, result, ctx, cfg)
     local lines, s, l
 
@@ -287,6 +287,26 @@ describe("should show signature ", function()
     eq(13, l)
   end)
 
+  it("should ignore signature for other buffers", function()
+    local ctx = { method = "textDocument/signatureHelp", client_id = 1, bufnr = vim.api.nvim_get_current_buf() + 1 }
+    local handler_result
+
+    local cfg1 = {
+      check_completion_visible = true,
+      check_client_handlers = true,
+      trigger_from_lsp_sig = true,
+      line_to_cursor = "\ttime.Date(1999, 12, 31",
+      triggered_chars = { "(", "," },
+    }
+    _LSP_SIG_CFG.log_path = "" -- set so the debug info will out put to console
+    if nvim_6 then
+      handler_result = signature.signature_handler(nil, result, ctx, cfg1)
+    else
+      handler_result = signature.signature_handler(nil, "", result, 1, 1, cfg1)
+    end
+    eq(nil, handler_result)
+  end)
+
   it("should show multi signature csharp", function()
     local cfg_cs = {
       check_completion_visible = true,
@@ -295,7 +315,7 @@ describe("should show signature ", function()
       line_to_cursor = "\tEditorGUI.PropertyField(Rect, Seri",
       triggered_chars = { "(", "," },
     }
-    local ctx = { method = "textDocument/signatureHelp", client_id = 1, bufnr = 0 }
+    local ctx = { method = "textDocument/signatureHelp", client_id = 1, bufnr = vim.api.nvim_get_current_buf() }
     -- local lines, s, l = signature.signature_handler(nil, result, ctx, cfg)
     local lines, s, l
 
@@ -337,7 +357,7 @@ describe("should show signature ", function()
       triggered_chars = { "(", "," },
     }
 
-    local ctx = { method = "textDocument/signatureHelp", client_id = 1, bufnr = 0 }
+    local ctx = { method = "textDocument/signatureHelp", client_id = 1, bufnr = vim.api.nvim_get_current_buf() }
 
     local lines, s, l
     if nvim_6 then
@@ -378,7 +398,7 @@ describe("should show signature ", function()
       triggered_chars = { "(", "," },
     }
 
-    local ctx = { method = "textDocument/signatureHelp", client_id = 1, bufnr = 0 }
+    local ctx = { method = "textDocument/signatureHelp", client_id = 1, bufnr = vim.api.nvim_get_current_buf() }
     local lines, s, l
     if nvim_6 then
       lines, s, l = signature.signature_handler(nil, result, ctx, cfg)


### PR DESCRIPTION
Language servers can be slow to respond to the
`textDocument/signatureHelp` request. During that time, the user could have moved to another buffer. The signature would be shown for the current buffer even though it was meant for some other buffer.

In this reproduction, I modify some code to make `tsserver` busy, quickly ask for `signatureHelp` and then quickly open Telescope:

https://user-images.githubusercontent.com/889383/202849435-e4ec105f-3b2f-4573-b0cd-a56decb43947.mp4


Let's only show the signature if it is for the current buffer.

The same Telescope bug reproduction with the fix from this PR (it no longer causes an error because the signature is ignored):


https://user-images.githubusercontent.com/889383/202849512-c1595d6d-9c55-4f2f-8b76-bef5781bc9d7.mp4



This bugfix is cherry-picked from [the Neovim core `signature_help` LSP handler](https://github.com/neovim/neovim/pull/21121).