### PR TITLE
Fix breaking typo

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -105,7 +105,7 @@ local function virtual_hint(hint, off_y)
     else
       show_at = cur_line + 1 -- show at below line
     end
-  ends
+  end
 
   if _LSP_SIG_CFG.floating_window == false then
     local prev_line, next_line


### PR DESCRIPTION
This error was annoying me very much

```
Error executing vim.schedule lua callback: vim/_init_packages.lua:0: ...cker/start/lsp_signature.nvim/lua/lsp_signature/init.l
ua:110: '=' expected near 'if'
stack traceback:
        [C]: in function 'error'
        vim/_init_packages.lua: in function <vim/_init_packages.lua:0>
```