### PR TITLE
Fix virtual text doesn't show

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -128,8 +128,8 @@ local function virtual_hint(hint, off_y)
     log("virtual text only :", prev_line, next_line, r, show_at, pl)
   end
 
-  if cur_line == 0 then
-    show_at = 0
+  if lines_above == 0 then
+    show_at = cur_line
   end
   -- get show at line
   if not pl then


### PR DESCRIPTION
when current line is the first line of current window(lines_above = 0), the value of show_at is still cur_line - 1, it should be changed to cur_line. and new code is compatible with the old code which is when current line is the first line of buffer, show_at = 0. #241