### PR TITLE
feat (config): pass woff to `floating_window_off_x` function

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -470,7 +470,7 @@ local signature_handler = function(err, result, ctx, config)
   if _LSP_SIG_CFG.floating_window_off_x then
     local offx = _LSP_SIG_CFG.floating_window_off_x
     if type(offx) == 'function' then
-      woff = woff + offx({ woff = woff })
+      woff = woff + offx({ x_off = woff })
     else
       woff = woff + offx
     end

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -470,7 +470,7 @@ local signature_handler = function(err, result, ctx, config)
   if _LSP_SIG_CFG.floating_window_off_x then
     local offx = _LSP_SIG_CFG.floating_window_off_x
     if type(offx) == 'function' then
-      woff = woff + offx({})
+      woff = woff + offx({ woff = woff })
     else
       woff = woff + offx
     end


### PR DESCRIPTION
Hi, thanks for the plugin!

May I have the value of `woff` passed to `floating_window_off_x` function?

I want to position the floating window at an absolute position (such that it anchors to the colorcolumn), but since the code adds whatever value `woff` to the output value, it is really hard to accomplish.

With the `woff` value passed to the function, I will be able to do something like this to place the window at the exact position I want.

```lua
floating_window_off_x = function(info)
  local woff = info.woff
  local the_absolute_position_i_want = 100
  local cur_pos = vim.api.nvim_win_get_cursor(0)[2] + 1
  return the_absolute_position_i_want - woff - cur_pos
end
```

BTW, what does `woff` stand for? _Width of function_? _Word offset_?

Thanks in advance,
pysan3