### PR TITLE
fix freezes on using lsp_signature with rust-tools

### DIFF
--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -696,7 +696,7 @@ end
 
 helper.completion_visible = function()
   local hascmp, cmp = pcall(require, 'cmp')
-  local hasrusttools, rusttools = pcall(require, 'rust-tools')
+  local hasrusttools = pcall(require, 'rust-tools')
   if hasrusttools then
     return true
   end

--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -696,6 +696,10 @@ end
 
 helper.completion_visible = function()
   local hascmp, cmp = pcall(require, 'cmp')
+  local hasrusttools, rusttools = pcall(require, 'rust-tools')
+  if hasrusttools then
+    return true
+  end
   if hascmp then
     return cmp.visible()
   end


### PR DESCRIPTION
When i use [lsp_signature.nvim](https://github.com/ray-x/lsp_signature.nvim) with [rust-tools.nvim](https://github.com/simrat39/rust-tools.nvim) i get strange freezes when writing function arguments. Video of freezes related.

https://github.com/ray-x/lsp_signature.nvim/assets/73785768/47604bd5-f187-4780-ba1b-e7bb28aab5fc

How did I find out it referenced with check of visible in nvim-cmp. I know it's not good solution, but I have no more information about it...
 