### PR TITLE
fix: attempt to call field '_trim' (a nil value) error

### DIFF
--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -390,7 +390,7 @@ helper.cal_pos = function(contents, opts)
     return {}, 2
   end
   local util = vim.lsp.util
-  contents = util._trim(contents, opts)
+  contents = vim.split(table.concat(contents, "\n"), "\n", { trimempty = true })
   -- there are 2 cases:
   -- 1. contents[1] = "```{language_id}", and contents[#contents] = "```", the code fences will be removed
   --    and return language_id


### PR DESCRIPTION
This pr fixes the following error on nightly.

```
Error executing vim.schedule lua callback: ...pack/opt/lsp_signature.nvim/lua/lsp_signature/helper.lua:393: attempt to call field '_trim' (a nil value)
stack traceback:
	...pack/opt/lsp_signature.nvim/lua/lsp_signature/helper.lua:393: in function 'cal_pos'
	...ptpack/opt/lsp_signature.nvim/lua/lsp_signature/init.lua:501: in function 'handler'
	/home/notomo/.local/nvim/share/nvim/runtime/lua/vim/lsp.lua:1505: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

📝
- `vim.lsp.util._trim` is not public function. `_trim` is removed on nightly.
- vim.split trimempty option is implemented from v.0.6.0: https://github.com/neovim/neovim/releases/tag/v0.6.0
