### PR TITLE
fix: cursor position outside buffer error

### DIFF
--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -759,7 +759,7 @@ end
 -- from vim.lsp.util deprecated function
 helper.trim_empty_lines = function(lines)
   local new_list = {}
-  for i, str in ipairs(lines) do
+  for _, str in ipairs(lines) do
     if str ~= '' and str then
       table.insert(new_list, str)
     end

--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -678,7 +678,7 @@ helper.highlight_parameter = function(s, l)
     end
     if line == 1 then
       -- scroll to top
-      vim.api.nvim_win_set_cursor(_LSP_SIG_CFG.winnr, { 2, 0 })
+      pcall(vim.api.nvim_win_set_cursor, _LSP_SIG_CFG.winnr, { 2, 0 })
     end
     if _LSP_SIG_CFG.bufnr and api.nvim_buf_is_valid(_LSP_SIG_CFG.bufnr) then
       log('extmark', _LSP_SIG_CFG.bufnr, s, l, #_LSP_SIG_CFG.padding)


### PR DESCRIPTION
## Bugfix: Cursor Position Error in `lsp_signature` Plugin during Parameter Input

### Description

Under Neovim 0.9.4, the `lsp_signature` plugin encountered a critical error when typing parameters inside a function, resulting in the following error:

```plaintext
Error executing vim.schedule lua callback: ...vim/lazy/lsp_signature.nvim/lua/lsp_signature/helper.lua:677: Cursor position outside buffer
stack traceback:
	[C]: in function 'nvim_win_set_cursor'
	...vim/lazy/lsp_signature.nvim/lua/lsp_signature/helper.lua:677: in function 'highlight_parameter'
	.../nvim/lazy/lsp_signature.nvim/lua/lsp_signature/init.lua:618: in function 'handler'
	...bob/v0.9.4/nvim-macos/share/nvim/runtime/lua/vim/lsp.lua:1393: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

### Changes Made

- Addressed the cursor position error during parameter input inside a function in the `lsp_signature` plugin.
- Wrapped the problematic function call in `helper.lua` within a protected call to ignore errors, preventing the plugin from throwing an exception for cursor position outside the buffer.