### PR TITLE
fix: Use get_active_clients if Neovim <0.10

### DIFF
--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -846,4 +846,12 @@ function helper.make_floating_popup_options(width, height, opts)
   }
 end
 
+function helper.get_clients(opts)
+  if vim.fn.has('nvim-0.10') == 1 then
+    return vim.lsp.get_clients(opts)
+  else
+    return vim.lsp.get_active_clients(opts)
+  end
+end
+
 return helper

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -624,7 +624,7 @@ local signature = function(opts)
 
   local bufnr = api.nvim_get_current_buf()
   local pos = api.nvim_win_get_cursor(0)
-  local clients = vim.lsp.get_active_clients({ bufnr = bufnr })
+  local clients = helper.get_clients({ bufnr = bufnr })
   local ft = vim.opt_local.filetype:get()
   local disabled = { 'TelescopePrompt', 'guihua', 'guihua_rust', 'clap_input', '' }
 
@@ -1025,7 +1025,7 @@ M.check_signature_should_close = function()
   then
     local bufnr = vim.api.nvim_get_current_buf()
     local pos = api.nvim_win_get_cursor(0)
-    local clients = vim.lsp.get_clients({ bufnr = bufnr })
+    local clients = helper.get_clients({ bufnr = bufnr })
     local line = api.nvim_get_current_line()
     local line_to_cursor = line:sub(1, pos[2])
     local signature_cap, triggered, trigger_position, _ =


### PR DESCRIPTION
Fixes https://github.com/ray-x/lsp_signature.nvim/issues/311

See https://neovim.io/doc/user/news.html

![image](https://github.com/ray-x/lsp_signature.nvim/assets/16181067/8a6d5096-0ba0-4b88-b370-2e90181d0076)
