### PR TITLE
fix: "Attempt to call field 'get_clients' (a nil value)" error for some 0.10 versions

### DIFF
--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -847,7 +847,7 @@ function helper.make_floating_popup_options(width, height, opts)
 end
 
 function helper.get_clients(opts)
-  if vim.fn.has('nvim-0.10') == 1 then
+  if vim.lsp.get_clients then
     return vim.lsp.get_clients(opts)
   else
     return vim.lsp.get_active_clients(opts)


### PR DESCRIPTION
I know PR #312 was made to try and address this issue. But this error is still popping up for me on the latest prerelease version of Neovim (NVIM v0.10.0-dev-2539+ga69c72063 at the moment) with the macos build. With this PR, I intend to fix this issue by checking if the method "vim.lsp.get_clients" exists before running it, and if not then run "vim.lsp.get_active_clients".