### PR TITLE
fix: remove use of `vim.lsp.util.try_trim_markdown_code_blocks()`

### DIFF
--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -415,7 +415,7 @@ helper.cal_pos = function(contents, opts)
   -- 1. contents[1] = "```{language_id}", and contents[#contents] = "```", the code fences will be removed
   --    and return language_id
   -- 2. in other cases, no lines will be removed, and return "markdown"
-  local filetype = util.try_trim_markdown_code_blocks(contents)
+  local filetype = helper.try_trim_markdown_code_blocks(contents)
   log(vim.inspect(contents))
 
   local width, height = util._make_floating_popup_size(contents, opts)


### PR DESCRIPTION
This PR will fix the following deprecated warning.

```
vim.lsp.util.try_trim_markdown_code_blocks() is deprecated, use nil instead. :help deprecated
Feature will be removed in Nvim 0.12
stack traceback:
	...tomo/.local/nvim/share/nvim/runtime/lua/vim/lsp/util.lua:1880: in function 'try_trim_markdown_code_blocks'
	...pack/opt/lsp_signature.nvim/lua/lsp_signature/helper.lua:418: in function 'cal_pos'
	...ptpack/opt/lsp_signature.nvim/lua/lsp_signature/init.lua:502: in function 'handler'
	...mo/.local/nvim/share/nvim/runtime/lua/vim/lsp/client.lua:685: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```
