### PR TITLE
modify hint_prefix to support multiple icons

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -115,19 +115,31 @@ local function virtual_hint(hint, off_y)
   end
   local pl
   local completion_visible = helper.completion_visible()
-  if off_y ~= nil and off_y < 0 then -- floating win above first
-    if completion_visible then
-      show_at = cur_line -- pum, show at current line
-    else
-      show_at = cur_line - 1 -- show at below line
-    end
-  end
+  local hp = type(_LSP_SIG_CFG.hint_prefix) == "string"
+    and _LSP_SIG_CFG.hint_prefix
 
-  if off_y ~= nil and off_y > 0 then
+  if off_y and off_y ~= 0 then
+    -- stay out of the way of the pum
     if completion_visible then
-      show_at = cur_line -- pum, show at current line
+      show_at = cur_line
+      if type(_LSP_SIG_CFG.hint_prefix) == "table" then
+        hp = _LSP_SIG_CFG.hint_prefix.current
+      end
+    end
+
+    -- if no pum, show at user configured line
+    if off_y > 0 then
+      -- line below
+      show_at = cur_line + 1
+      if type(_LSP_SIG_CFG.hint_prefix) == "table" then
+        hp = _LSP_SIG_CFG.hint_prefix.below
+      end
     else
-      show_at = cur_line + 1 -- show at below line
+      -- line above
+      show_at = cur_line - 1
+      if type(_LSP_SIG_CFG.hint_prefix) == "table" then
+        hp = _LSP_SIG_CFG.hint_prefix.above
+      end
     end
   end
 
@@ -140,26 +152,39 @@ local function virtual_hint(hint, off_y)
     if prev_line and vim.fn.strdisplaywidth(prev_line) < r[2] then
       show_at = cur_line - 1
       pl = prev_line
+      if type(_LSP_SIG_CFG.hint_prefix) == "table" then
+        hp = _LSP_SIG_CFG.hint_prefix.above
+      end
     elseif next_line and dwidth(next_line) < r[2] + 2 and not completion_visible then
       show_at = cur_line + 1
       pl = next_line
+      if type(_LSP_SIG_CFG.hint_prefix) == "table" then
+        hp = _LSP_SIG_CFG.hint_prefix.below
+      end
     else
       show_at = cur_line
+      if type(_LSP_SIG_CFG.hint_prefix) == "table" then
+        hp = _LSP_SIG_CFG.hint_prefix.current
+      end
     end
 
     log('virtual text only :', prev_line, next_line, r, show_at, pl)
   end
 
-  if lines_above == 0 then
-    show_at = cur_line
-  end
   -- get show at line
   if not pl then
     pl = vim.api.nvim_buf_get_lines(0, show_at, show_at + 1, false)[1]
   end
-  if pl == nil then
-    show_at = cur_line -- no lines below
+
+  -- if there are no lines above
+  -- show at current line
+  if lines_above == 0 or not pl then
+    show_at = cur_line
+    if type(_LSP_SIG_CFG.hint_prefix) == "table" then
+      hp = _LSP_SIG_CFG.hint_prefix.current
+    end
   end
+
   pl = pl or ''
   local pad = ''
   local offset = r[2]
@@ -170,7 +195,7 @@ local function virtual_hint(hint, off_y)
     if show_at ~= cur_line and line_to_cursor_width > pl_width + 1 then
       pad = string.rep(' ', line_to_cursor_width - pl_width)
       local width = vim.api.nvim_win_get_width(0)
-      local hint_width = dwidth(_LSP_SIG_CFG.hint_prefix .. hint)
+      local hint_width = dwidth(hp .. hint)
       -- todo: 6 is width of sign+linenumber column
       if #pad + pl_width + hint_width + 6 > width then
         pad = string.rep(' ', math.max(1, line_to_cursor_width - pl_width - hint_width - 6))
@@ -201,7 +226,7 @@ local function virtual_hint(hint, off_y)
     log('virtual text: ', cur_line, 'invalid offset')
     return -- no offset found
   end
-  local vt = { pad .. _LSP_SIG_CFG.hint_prefix .. hint, _LSP_SIG_CFG.hint_scheme }
+  local vt = { pad .. hp .. hint, _LSP_SIG_CFG.hint_scheme }
   if inline_display then
     if type(inline_display) == 'boolean' then
       inline_display = 'inline'


### PR DESCRIPTION
hint_prefix now optionally supports three icons:
- above: when the hint is shown on the line above
- current: when the hint is shown on the current line
- below: when the hint is shown on the line below

a few if statements were also rewritten to be more compact

example screenshots:
above:
![above](https://github.com/ray-x/lsp_signature.nvim/assets/73189703/f6ab1413-fcd6-4e7d-826d-194d6e5cdb2b)
current:
![current](https://github.com/ray-x/lsp_signature.nvim/assets/73189703/8cf2c835-cbee-4bec-a58c-a44f0a203243)
below:
![below](https://github.com/ray-x/lsp_signature.nvim/assets/73189703/c714962b-929d-4443-9cd4-21d19e92416a)
