### PR TITLE
[feat]: multiple hint_prefix icons, based on hint's location

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ e.g.
   fix_pos = false,  -- set to true, the floating window will not auto-close until finish all parameters
   hint_enable = true, -- virtual hint enable
   hint_prefix = "🐼 ",  -- Panda for parameter, NOTE: for the terminal not support emoji, might crash
+  -- or, provide a table with 3 icons
+  -- hint_prefix = {
+  --     above = "↙ ",  -- when the hint is on the line above the current line
+  --     current = "← ",  -- when the hint is on the same line
+  --     below = "↖ "  -- when the hint is on the line below the current line
+  -- }
   hint_scheme = "String",
   hint_inline = function() return false end,  -- should the hint be inline(nvim 0.10 only)?  default false
   -- return true | 'inline' to show hint inline, return 'eol' to show hint at end of line, return false to disable

--- a/doc/lsp_signature.txt
+++ b/doc/lsp_signature.txt
@@ -118,6 +118,12 @@ FULL CONFIGURATION (WITH DEFAULT VALUES) *lsp_signature-full_configuration_(with
       fix_pos = false,  -- set to true, the floating window will not auto-close until finish all parameters
       hint_enable = true, -- virtual hint enable
       hint_prefix = "🐼 ",  -- Panda for parameter
+      -- or, provide a table with 3 icons
+      -- hint_prefix = {
+      --     above = "↙ ",  -- when the hint is on the line above the current line
+      --     current = "← ",  -- when the hint is on the same line
+      --     below = "↖ "  -- when the hint is on the line below the current line
+      -- }
       hint_scheme = "String",
       hi_parameter = "LspSignatureActiveParameter", -- how your parameter will be highlight
       max_height = 12, -- max height of signature floating_window, if content is more than max_height, you can scroll down

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -116,31 +116,38 @@ local function virtual_hint(hint, off_y)
   local pl
   local completion_visible = helper.completion_visible()
   local hp = type(_LSP_SIG_CFG.hint_prefix) == 'string' and _LSP_SIG_CFG.hint_prefix
+    or (type(_LSP_SIG_CFG.hint_prefix) == 'table' and _LSP_SIG_CFG.hint_prefix.current)
+    or '🐼 '
 
   if off_y and off_y ~= 0 then
+    local inline = type(_LSP_SIG_CFG.hint_inline) == 'function'
+        and _LSP_SIG_CFG.hint_inline() == 'inline'
+      or _LSP_SIG_CFG.hint_inline
     -- stay out of the way of the pum
-    if completion_visible then
+    if completion_visible or inline then
       show_at = cur_line
       if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
         hp = _LSP_SIG_CFG.hint_prefix.current or '🐼 '
       end
-    end
-
-    -- if no pum, show at user configured line
-    if off_y > 0 then
-      -- line below
-      show_at = cur_line + 1
-      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.below or '🐼 '
-      end
     else
-      -- line above
-      show_at = cur_line - 1
-      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.above or '🐼 '
+      -- if no pum, show at user configured line
+      if off_y > 0 then
+        -- line below
+        show_at = cur_line + 1
+        if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
+          hp = _LSP_SIG_CFG.hint_prefix.below or '🐼 '
+        end
+      end
+      if off_y < 0 then
+        -- line above
+        show_at = cur_line - 1
+        if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
+          hp = _LSP_SIG_CFG.hint_prefix.above or '🐼 '
+        end
       end
     end
   end
+
 
   if _LSP_SIG_CFG.floating_window == false then
     local prev_line, next_line

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -180,7 +180,7 @@ local function virtual_hint(hint, off_y)
     if show_at ~= cur_line and line_to_cursor_width > pl_width + 1 then
       pad = string.rep(' ', line_to_cursor_width - pl_width)
       local width = vim.api.nvim_win_get_width(0)
-      local hint_width = dwidth(_LSP_SIG_CFG.hint_prefix .. hint)
+      local hint_width = dwidth(hp .. hint)
       -- todo: 6 is width of sign+linenumber column
       if #pad + pl_width + hint_width + 6 > width then
         pad = string.rep(' ', math.max(1, line_to_cursor_width - pl_width - hint_width - 6))
@@ -211,7 +211,7 @@ local function virtual_hint(hint, off_y)
     log('virtual text: ', cur_line, 'invalid offset')
     return -- no offset found
   end
-  local vt = { pad .. _LSP_SIG_CFG.hint_prefix .. hint, _LSP_SIG_CFG.hint_scheme }
+  local vt = { pad .. hp .. hint, _LSP_SIG_CFG.hint_scheme }
   if inline_display then
     if type(inline_display) == 'boolean' then
       inline_display = 'inline'

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -122,7 +122,7 @@ local function virtual_hint(hint, off_y)
     if completion_visible then
       show_at = cur_line
       if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.current
+        hp = _LSP_SIG_CFG.hint_prefix.current or '🐼 '
       end
     end
 
@@ -131,13 +131,13 @@ local function virtual_hint(hint, off_y)
       -- line below
       show_at = cur_line + 1
       if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.below
+        hp = _LSP_SIG_CFG.hint_prefix.below or '🐼 '
       end
     else
       -- line above
       show_at = cur_line - 1
       if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.above
+        hp = _LSP_SIG_CFG.hint_prefix.above or '🐼 '
       end
     end
   end
@@ -152,18 +152,18 @@ local function virtual_hint(hint, off_y)
       show_at = cur_line - 1
       pl = prev_line
       if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.above
+        hp = _LSP_SIG_CFG.hint_prefix.above or '🐼 '
       end
     elseif next_line and dwidth(next_line) < r[2] + 2 and not completion_visible then
       show_at = cur_line + 1
       pl = next_line
       if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.below
+        hp = _LSP_SIG_CFG.hint_prefix.below or '🐼 '
       end
     else
       show_at = cur_line
       if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.current
+        hp = _LSP_SIG_CFG.hint_prefix.current or '🐼 '
       end
     end
 

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -115,19 +115,20 @@ local function virtual_hint(hint, off_y)
   end
   local pl
   local completion_visible = helper.completion_visible()
-  if off_y ~= nil and off_y < 0 then -- floating win above first
-    if completion_visible then
-      show_at = cur_line -- pum, show at current line
-    else
-      show_at = cur_line - 1 -- show at below line
-    end
-  end
 
-  if off_y ~= nil and off_y > 0 then
+  if off_y and off_y ~= 0 then
+    -- stay out of the way of the pum
     if completion_visible then
-      show_at = cur_line -- pum, show at current line
+      show_at = cur_line
+    end
+
+    -- if no pum, show at user configured line
+    if off_y > 0 then
+      -- line below
+      show_at = cur_line + 1
     else
-      show_at = cur_line + 1 -- show at below line
+      -- line above
+      show_at = cur_line - 1
     end
   end
 
@@ -150,16 +151,15 @@ local function virtual_hint(hint, off_y)
     log('virtual text only :', prev_line, next_line, r, show_at, pl)
   end
 
-  if lines_above == 0 then
-    show_at = cur_line
-  end
   -- get show at line
   if not pl then
     pl = vim.api.nvim_buf_get_lines(0, show_at, show_at + 1, false)[1]
   end
-  if pl == nil then
-    show_at = cur_line -- no lines below
+  -- if there are no lines above the current one
+  if lines_above == 0 and not pl then
+    show_at = cur_line
   end
+  
   pl = pl or ''
   local pad = ''
   local offset = r[2]

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -115,20 +115,30 @@ local function virtual_hint(hint, off_y)
   end
   local pl
   local completion_visible = helper.completion_visible()
+  local hp = type(_LSP_SIG_CFG.hint_prefix) == 'string' and _LSP_SIG_CFG.hint_prefix
 
   if off_y and off_y ~= 0 then
     -- stay out of the way of the pum
     if completion_visible then
       show_at = cur_line
+      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
+        hp = _LSP_SIG_CFG.hint_prefix.current
+      end
     end
 
     -- if no pum, show at user configured line
     if off_y > 0 then
       -- line below
       show_at = cur_line + 1
+      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
+        hp = _LSP_SIG_CFG.hint_prefix.below
+      end
     else
       -- line above
       show_at = cur_line - 1
+      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
+        hp = _LSP_SIG_CFG.hint_prefix.above
+      end
     end
   end
 
@@ -141,25 +151,25 @@ local function virtual_hint(hint, off_y)
     if prev_line and vim.fn.strdisplaywidth(prev_line) < r[2] then
       show_at = cur_line - 1
       pl = prev_line
+      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
+        hp = _LSP_SIG_CFG.hint_prefix.above
+      end
     elseif next_line and dwidth(next_line) < r[2] + 2 and not completion_visible then
       show_at = cur_line + 1
       pl = next_line
+      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
+        hp = _LSP_SIG_CFG.hint_prefix.below
+      end
     else
       show_at = cur_line
+      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
+        hp = _LSP_SIG_CFG.hint_prefix.current
+      end
     end
 
     log('virtual text only :', prev_line, next_line, r, show_at, pl)
   end
 
-  -- get show at line
-  if not pl then
-    pl = vim.api.nvim_buf_get_lines(0, show_at, show_at + 1, false)[1]
-  end
-  -- if there are no lines above the current one
-  if lines_above == 0 and not pl then
-    show_at = cur_line
-  end
-  
   pl = pl or ''
   local pad = ''
   local offset = r[2]

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -148,7 +148,6 @@ local function virtual_hint(hint, off_y)
     end
   end
 
-
   if _LSP_SIG_CFG.floating_window == false then
     local prev_line, next_line
     if cur_line > 0 then


### PR DESCRIPTION
This PR aims to add support for 3 separate icons to be used for the hint_prefix, based on where the hint is displayed:
 - 'above' the current line
 - 'current' line
 - 'below' the current line

When a string is given as the option to 'hint_prefix', it's assumed to be the only icon used.

screenshots:
![above](https://github.com/ray-x/lsp_signature.nvim/assets/73189703/96d38b42-ed14-4890-824d-70606f1e2969)
![current](https://github.com/ray-x/lsp_signature.nvim/assets/73189703/ba92be7a-d808-4f52-9a39-dfb055df942a)
![below](https://github.com/ray-x/lsp_signature.nvim/assets/73189703/9c86b131-a8d7-4ddf-a556-cf9d88bad26a)
