### PR TITLE
fix: loaded events should not be deleted when the augroup exists.

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -915,7 +915,7 @@ end
 M.on_attach = function(cfg, bufnr)
   bufnr = bufnr or api.nvim_get_current_buf()
 
-  local augroup = api.nvim_create_augroup('Signature', {})
+  local augroup = api.nvim_create_augroup('Signature', { clear = false })
   api.nvim_create_autocmd('InsertEnter', {
     group = augroup,
     buffer = bufnr,


### PR DESCRIPTION
Hi there, best plugins!

The `on_attach` function will execute when the corresponding buffer is created If a file already bound to LSP. While preserving the original behavior, creating a new augroup will remove the previously loaded events (by default). This will result in the inability to use all the features of lsp_signature.nvim in the previous buffer. Sincerely hope this issue gets resolved promptly.


https://github.com/ray-x/lsp_signature.nvim/assets/38415769/3b29229f-8a6b-47cc-a307-ebb06c4376fe

Regards!