### PR TITLE
improve inlay-hint display and offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,11 @@ e.g.
   close_timeout = 4000, -- close floating window after ms when laster parameter is entered
   fix_pos = false,  -- set to true, the floating window will not auto-close until finish all parameters
   hint_enable = true, -- virtual hint enable
+  disable_lsp_inlay = false, -- disable lsp inlay hints that can cover the signature help
   hint_prefix = "🐼 ",  -- Panda for parameter, NOTE: for the terminal not support emoji, might crash
-  -- or, provide a table with 3 icons
+  -- or, provide a table with 4 icons
   -- hint_prefix = {
+  --     default = "🐼 ", -- if above/current/below is not specified
   --     above = "↙ ",  -- when the hint is on the line above the current line
   --     current = "← ",  -- when the hint is on the same line
   --     below = "↖ "  -- when the hint is on the line below the current line

--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -15,6 +15,28 @@ local function is_special(ch)
   return contains(special_chars, ch)
 end
 
+-- get inlay lsp hints of current line
+-- sample response
+--[[
+{ 26, 678, 31, {
+      ns_id = 54,
+      priority = 4096,
+      right_gravity = true,
+      virt_text = { { "x:", "LspInlayHint" }, { " " } },
+      virt_text_hide = false,
+      virt_text_pos = "inline",
+      virt_text_repeat_linebreak = false
+    }
+]] --
+local function inlay_hints()
+  local lsp_inlay = vim.api.nvim_create_namespace('vim_lsp_inlayhint')
+  local r = vim.api.nvim_win_get_cursor(0)
+  local start, _end = {r[1]-1, 0} , {r[1]-1, r[2]}
+  local mk = vim.api.nvim_buf_get_extmarks(0, lsp_inlay, start, _end,
+  {details=true})
+  return mk
+end
+
 local function fs_write(path, data)
   local uv = vim.uv or vim.loop
 
@@ -545,6 +567,31 @@ local make_floating_popup_size = function(contents, opts)
   end
 
   return width, height
+end
+
+helper.inline_string_width = function()
+  local width = fn.strdisplaywidth
+  local w = 0
+  -- if inlay hint enabled
+  if vim.lsp.inlay_hint.is_enabled({bufnr=0}) then
+    local hints = inlay_hints()
+    if hints == nil then
+      return w
+    end
+    -- virt_text = { { "x:", "LspInlayHint" }, { " " } },
+    for _, value in pairs(hints) do
+      -- helper.log(value)
+      local v = value[4] and value[4].virt_text or nil
+      if  v == nil then
+        helper.log('no virt_text', value)
+        return w
+      end
+      for _, v in pairs(v) do
+        w = w + width(v[1])
+      end
+    end
+  end
+  return w
 end
 
 helper.cal_pos = function(contents, opts)

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -55,7 +55,13 @@ _LSP_SIG_CFG = {
   end,
   -- also can be bool value fix floating_window position
   hint_enable = true, -- virtual hint
-  hint_prefix = '🐼 ',
+  disable_lsp_inlay = false,
+  hint_prefix = {
+    default = '🐼 ', -- Panda for parameter
+    --     above = "↙ ",  -- when the hint is on the line above the current line
+    --     current = "← ",  -- when the hint is on the same line
+    --     below = "↖ "  -- when the hint is on the line below the current line
+  },
   hint_scheme = 'String',
   hint_inline = function()
     -- options:
@@ -115,9 +121,17 @@ local function virtual_hint(hint, off_y)
   end
   local pl
   local completion_visible = helper.completion_visible()
-  local hp = type(_LSP_SIG_CFG.hint_prefix) == 'string' and _LSP_SIG_CFG.hint_prefix
-    or (type(_LSP_SIG_CFG.hint_prefix) == 'table' and _LSP_SIG_CFG.hint_prefix.current)
-    or '🐼 '
+  -- local hp = type(_LSP_SIG_CFG.hint_prefix) == 'string' and _LSP_SIG_CFG.hint_prefix
+  --   or (type(_LSP_SIG_CFG.hint_prefix) == 'table' and _LSP_SIG_CFG.hint_prefix.current)
+  --   or '🐼 '
+  local gethp = function(pos)
+    if type(_LSP_SIG_CFG.hint_prefix) == 'string' then
+      -- this should not happen
+      vim.notify('hint_prefix should be a table, please report an issue', vim.log.levels.ERROR)
+      return _LSP_SIG_CFG.hint_prefix
+    end
+    return _LSP_SIG_CFG.hint_prefix[pos] or _LSP_SIG_CFG.hint_prefix.default or '🐼 '
+  end
 
   if off_y and off_y ~= 0 then
     local inline = type(_LSP_SIG_CFG.hint_inline) == 'function'
@@ -126,28 +140,23 @@ local function virtual_hint(hint, off_y)
     -- stay out of the way of the pum
     if completion_visible or inline then
       show_at = cur_line
-      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.current or '🐼 '
-      end
+      hp = gethp('current')
     else
       -- if no pum, show at user configured line
       if off_y > 0 then
         -- line below
         show_at = cur_line + 1
-        if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-          hp = _LSP_SIG_CFG.hint_prefix.below or '🐼 '
-        end
+        hp = gethp('below')
       end
       if off_y < 0 then
         -- line above
         show_at = cur_line - 1
-        if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-          hp = _LSP_SIG_CFG.hint_prefix.above or '🐼 '
-        end
+        hp = gethp('above')
       end
     end
   end
 
+  local hp = gethp('default')
   if _LSP_SIG_CFG.floating_window == false then
     local prev_line, next_line
     if cur_line > 0 then
@@ -157,20 +166,13 @@ local function virtual_hint(hint, off_y)
     if prev_line and vim.fn.strdisplaywidth(prev_line) < r[2] then
       show_at = cur_line - 1
       pl = prev_line
-      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.above or '🐼 '
-      end
+      hp = gethp('above')
     elseif next_line and dwidth(next_line) < r[2] + 2 and not completion_visible then
       show_at = cur_line + 1
-      pl = next_line
-      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.below or '🐼 '
-      end
+      hp = gethp('below')
     else
       show_at = cur_line
-      if type(_LSP_SIG_CFG.hint_prefix) == 'table' then
-        hp = _LSP_SIG_CFG.hint_prefix.current or '🐼 '
-      end
+      hp = gethp('current')
     end
 
     log('virtual text only :', prev_line, next_line, r, show_at, pl)
@@ -183,8 +185,11 @@ local function virtual_hint(hint, off_y)
   if inline_display == false then
     local line_to_cursor_width = dwidth(line_to_cursor)
     local pl_width = dwidth(pl)
+    -- log(pl, pl_width, line_to_cursor_width, r[2])
     if show_at ~= cur_line and line_to_cursor_width > pl_width + 1 then
-      pad = string.rep(' ', line_to_cursor_width - pl_width)
+      local off = line_to_cursor_width - pl_width
+      off = off + helper.inline_string_width()
+      pad = string.rep(' ', off)
       local width = vim.api.nvim_win_get_width(0)
       local hint_width = dwidth(hp .. hint)
       -- todo: 6 is width of sign+linenumber column
@@ -217,6 +222,7 @@ local function virtual_hint(hint, off_y)
     log('virtual text: ', cur_line, 'invalid offset')
     return -- no offset found
   end
+  local inlay_offset = helper.inline_string_width()
   local vt = { pad .. hp .. hint, _LSP_SIG_CFG.hint_scheme }
   if inline_display then
     if type(inline_display) == 'boolean' then
@@ -240,7 +246,14 @@ local function virtual_hint(hint, off_y)
       }
     )
   else -- I may deprecated this when nvim 0.10 release
-    log('virtual text: ', cur_line, show_at, vt)
+    local offset = offset + inlay_offset
+
+    log('virtual text: ', cur_line, show_at, offset, vt)
+    if show_at == cur_line then
+      offset = 0
+    else
+      offset = offset
+    end
     vim.api.nvim_buf_set_extmark(0, _LSP_SIG_VT_NS, show_at, 0, {
       virt_text = { vt },
       virt_text_pos = 'eol',
@@ -985,12 +998,6 @@ M.on_attach = function(cfg, bufnr)
   end
   -- stylua ignore end
 
-  if type(cfg) == 'table' then
-    _LSP_SIG_CFG = vim.tbl_extend('keep', cfg, _LSP_SIG_CFG)
-    cleanup_logs(cfg)
-    -- log(_LSP_SIG_CFG)
-  end
-
   if _LSP_SIG_CFG.bind then
     vim.lsp.handlers['textDocument/signatureHelp'] =
       vim.lsp.with(signature_handler, _LSP_SIG_CFG.handler_opts)
@@ -1184,6 +1191,17 @@ M.signature_handler = signature_handler
 M.setup = function(cfg)
   cfg = cfg or {}
   M.deprecated(cfg)
+
+  if type(cfg) == 'table' then
+    if cfg.hint_prefix and type(cfg.hint_prefix) == 'string' then
+      cfg.hint_prefix = {
+        default = cfg.hint_prefix, -- when the hint is on the same line
+      }
+    end
+    _LSP_SIG_CFG = vim.tbl_extend('keep', cfg, _LSP_SIG_CFG)
+    cleanup_logs(cfg)
+    -- log(_LSP_SIG_CFG)
+  end
   log('user cfg:', cfg)
   local _start_client = vim.lsp.start_client
   _LSP_SIG_VT_NS = api.nvim_create_namespace('lsp_signature_vt')


### PR DESCRIPTION
When inlay hint is enabled, the offset of virtual text may be incorrect,  it should look like this:
![image](https://github.com/ray-x/lsp_signature.nvim/assets/1681295/62452485-d631-4425-861b-c2d390ff64f5)
