### PR TITLE
Fix cursorhold_update Configuration Handling in lsp_signature.nvim

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -971,7 +971,6 @@ M.on_attach = function(cfg, bufnr)
     end,
     desc = 'signature on complete done',
   })
-  helper.cursor_hold(_LSP_SIG_CFG.cursorhold_update, bufnr)
   -- stylua ignore end
 
   if type(cfg) == 'table' then
@@ -979,6 +978,8 @@ M.on_attach = function(cfg, bufnr)
     cleanup_logs(cfg)
     -- log(_LSP_SIG_CFG)
   end
+
+  helper.cursor_hold(_LSP_SIG_CFG.cursorhold_update, bufnr)
 
   if _LSP_SIG_CFG.bind then
     vim.lsp.handlers['textDocument/signatureHelp'] =


### PR DESCRIPTION
Hello @ray-x,

I come from [Issue #298](https://github.com/ray-x/lsp_signature.nvim/issues/298). I encountered a problem while trying to apply the solution suggested in this issue. Specifically, I found that the configuration option `cursorhold_update = false` does not work as expected. The root cause appears to be that the `autocmd` is defined before the user's configuration is applied, resulting in the default settings being used.

Please review the changes and provide feedback. Additionally, it would be great if you could take a look at Issue #298 to confirm if there might be other underlying issues.