### PR TITLE
fix: keymaps config helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ e.g.
   -- e.g. move_cursor_key = '<M-p>',
   -- once moved to floating window, you can use <M-d>, <M-u> to move cursor up and down
   keymaps = {}  -- relate to move_cursor_key; the keymaps inside floating window
-  -- e.g. keymaps = { 'j', '<C-o>j' } this map j to <C-o>j in floating window
+  -- e.g. keymaps = { { 'j', '<C-o>j' }, } this map j to <C-o>j in floating window
   -- <M-d> and <M-u> are default keymaps to move cursor up and down
 }
 

--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -844,7 +844,7 @@ helper.set_keymaps = function(winnr, bufnr)
     end
     if maps and type(maps) == 'table' then
       for _, map in ipairs(maps) do
-        vim.keymap.set('i', map.lhs, map.rhs, { buffer = bufnr })
+        vim.keymap.set('i', map[1], map[2], { buffer = bufnr })
       end
     end
   end


### PR DESCRIPTION
This is a small patch. The `.lhs` and `.rhs` properties do not exist (any longer?; old api?). I have gotten errors trying to set custom keymaps.

This is written in the example config;
```lua
  keymaps = { "j", "<C-o>j" },
```
But this seems to provoke the following error:
![image](https://github.com/user-attachments/assets/91493a60-f067-48f8-be5b-d7525f16de37)

I pressume setting it in the following way was intended:
```lua
  keymaps = { { "j", "<C-o>j" }, { "k", "<C-o>k" }, },
```
It raises a similar error.

Using indexes to instead get the keymap table values resolves the issue and I presume does what was intended.