### PR TITLE
fix: make_position_params needs offset encoding in v0.11

### DIFF
--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -790,6 +790,26 @@ function helper.check_lsp_cap(clients, line_to_cursor)
   return signature_cap, triggered, trigger_position, triggered_chars
 end
 
+---@param extra_params table extends the position parameters
+---@return table|(fun(client: vim.lsp.Client, bufnr: integer): table) final parameters
+helper.make_position_params = function(extra_params)
+  if vim.fn.has('nvim-0.11') == 0 then
+    local params = vim.lsp.util.make_position_params()
+    if extra_params then
+      params = vim.tbl_deep_extend('force', params, extra_params)
+    end
+    return params
+  end
+  ---@param client vim.lsp.Client
+  return function(client, _)
+    local params = vim.lsp.util.make_position_params(0, client.offset_encoding)
+    if extra_params then
+      params = vim.tbl_deep_extend('force', params, extra_params)
+    end
+    return params
+  end
+end
+
 helper.highlight_parameter = function(s, l)
   _LSP_SIG_CFG.ns = api.nvim_create_namespace('lsp_signature_hi_parameter')
   local hi = _LSP_SIG_CFG.hi_parameter

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -708,10 +708,12 @@ local signature = function(opts)
     end
   end
 
-  local params = vim.lsp.util.make_position_params()
-  log('change trigger pos to ', params.position.character, trigger_position)
   local shift = math.max(1, trigger_position - 0)
-  params.position.character = shift
+  local params = helper.make_position_params({
+    position = {
+      character = shift,
+    },
+  })
   if opts.trigger == 'CursorHold' then
     return vim.lsp.buf_request(
       0,
@@ -1074,8 +1076,11 @@ M.check_signature_should_close = function()
       status_line = { hint = '', label = '' }
       return
     end
-    local params = vim.lsp.util.make_position_params()
-    params.position.character = math.max(trigger_position, 1)
+    local params = helper.make_position_params({
+      position = {
+        character = math.max(trigger_position, 1),
+      },
+    })
     line = api.nvim_get_current_line()
     line_to_cursor = line:sub(1, pos[2])
     -- Try using the already binded one, otherwise use it without custom config.
@@ -1148,7 +1153,7 @@ M.toggle_float_win = function()
     return _LSP_SIG_CFG.floating_window
   end
 
-  local params = vim.lsp.util.make_position_params()
+  local params = helper.make_position_params()
   local pos = api.nvim_win_get_cursor(0)
   local line = api.nvim_get_current_line()
   local line_to_cursor = line:sub(1, pos[2])


### PR DESCRIPTION
vim.lsp.util.make_position_params requires the explicit client encoding as of nvim v0.11

Fixes: https://github.com/ray-x/lsp_signature.nvim/issues/346