### PR TITLE
Added options to turn off automatically showing the signature on InsertEnter and when you begin to type.

### DIFF
--- a/lua/lsp_signature/codeaction.lua
+++ b/lua/lsp_signature/codeaction.lua
@@ -173,7 +173,6 @@ end
 
 --- Example function to demonstrate usage: logs unfilled fields to :messages.
 function M.show_unfilled_fields()
-
   M.collect_unfilled_fields_info(function(fields_info, ctx)
     log('Unfilled fields:', fields_info, ctx)
     if vim.tbl_isempty(fields_info) then

--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -25,7 +25,9 @@ helper.cursor_hold = function(enabled, bufnr)
       group = augroup,
       buffer = bufnr,
       callback = function()
-        require('lsp_signature').on_UpdateSignature()
+        if _LSP_SIG_CFG.auto_show_insert_enter then
+          require('lsp_signature').on_UpdateSignature()
+	    end
       end,
       desc = 'signature on cursor hold',
     })

--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -27,7 +27,7 @@ helper.cursor_hold = function(enabled, bufnr)
       callback = function()
         if _LSP_SIG_CFG.auto_show_insert_enter then
           require('lsp_signature').on_UpdateSignature()
-	    end
+        end
       end,
       desc = 'signature on cursor hold',
     })

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -96,6 +96,8 @@ _LSP_SIG_CFG = {
   move_cursor_key = nil, -- use nvim_set_current_win
   move_signature_window_key = {}, -- move floating window, default ['<M-j>', '<M-k>']
   show_struct = { enable = false }, -- experimental: show struct info
+  auto_show_insert_enter = true,
+  auto_show_when_typing = true,
 
   --- private vars
   winnr = nil,
@@ -956,7 +958,9 @@ M.on_attach = function(cfg, bufnr)
     group = augroup,
     buffer = bufnr,
     callback = function()
-      require('lsp_signature').on_InsertEnter()
+	  if cfg.auto_show_insert_enter then
+        require('lsp_signature').on_InsertEnter()
+      end
     end,
     desc = 'signature on insert enter',
   })
@@ -964,7 +968,9 @@ M.on_attach = function(cfg, bufnr)
     group = augroup,
     buffer = bufnr,
     callback = function()
-      require('lsp_signature').on_InsertLeave()
+	  if cfg.auto_show_insert_enter then
+        require('lsp_signature').on_InsertLeave()
+      end
     end,
     desc = 'signature on insert leave',
   })
@@ -1013,7 +1019,7 @@ M.on_attach = function(cfg, bufnr)
 
   if _LSP_SIG_CFG.toggle_key then
     vim.keymap.set({ 'i', 'v', 's' }, _LSP_SIG_CFG.toggle_key, function()
-      require('lsp_signature').toggle_float_win()
+      require('lsp_signature').toggle_float_win(cfg)
     end, { silent = true, noremap = true, buffer = bufnr, desc = 'toggle signature' })
   end
   if _LSP_SIG_CFG.select_signature_key then
@@ -1178,7 +1184,9 @@ M.toggle_float_win = function()
     vim.api.nvim_create_autocmd('InsertCharPre', {
       callback = function()
         -- disable cursor hold event until next insert enter
+		if _LSP_SIG_CFG.auto_show_when_typing then
         helper.cursor_hold(_LSP_SIG_CFG.cursorhold_update, vim.api.nvim_get_current_buf())
+	    end
       end,
       once = true, -- trigger once
     })

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -958,7 +958,7 @@ M.on_attach = function(cfg, bufnr)
     group = augroup,
     buffer = bufnr,
     callback = function()
-	  if cfg.auto_show_insert_enter then
+      if cfg.auto_show_insert_enter then
         require('lsp_signature').on_InsertEnter()
       end
     end,
@@ -968,7 +968,7 @@ M.on_attach = function(cfg, bufnr)
     group = augroup,
     buffer = bufnr,
     callback = function()
-	  if cfg.auto_show_insert_enter then
+      if cfg.auto_show_insert_enter then
         require('lsp_signature').on_InsertLeave()
       end
     end,
@@ -1184,9 +1184,9 @@ M.toggle_float_win = function()
     vim.api.nvim_create_autocmd('InsertCharPre', {
       callback = function()
         -- disable cursor hold event until next insert enter
-		if _LSP_SIG_CFG.auto_show_when_typing then
-        helper.cursor_hold(_LSP_SIG_CFG.cursorhold_update, vim.api.nvim_get_current_buf())
-	    end
+        if _LSP_SIG_CFG.auto_show_when_typing then
+          helper.cursor_hold(_LSP_SIG_CFG.cursorhold_update, vim.api.nvim_get_current_buf())
+        end
       end,
       once = true, -- trigger once
     })


### PR DESCRIPTION
Now, if you have both `auto_show_insert_enter = false` and `auto_show_when_typing = false`, the signature help will only show if you use your defined `toggle_key`.

Fixes [#335](https://github.com/ray-x/lsp_signature.nvim/issues/335).