### PR TITLE
Fixing the hint to show when using the roslyn lsp

### DIFF
--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -259,7 +259,8 @@ helper.match_parameter = function(result, config)
   end
   if nextParameter.documentation and #nextParameter.documentation > 0 then
     nexp = nexp .. ': ' .. nextParameter.documentation
-  elseif type(nextParameter.documentation) == 'table' and nextParameter.documentation.value then -- this is to follow when the documentation is a table like {kind= xxx, value= zzz}
+  -- this is to follow when the documentation is a table like {kind= xxx, value= zzz}
+  elseif type(nextParameter.documentation) == 'table' and nextParameter.documentation.value then
     nexp = nexp .. ': ' .. nextParameter.documentation.value
   end
 

--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -259,6 +259,8 @@ helper.match_parameter = function(result, config)
   end
   if nextParameter.documentation and #nextParameter.documentation > 0 then
     nexp = nexp .. ': ' .. nextParameter.documentation
+  elseif nextParameter.documentation.value and #nextParameter.documentation.value > 0 then -- this is to follow when the documentation is a table like {kind= xxx, value= zzz}
+    nexp = nexp .. ': ' .. nextParameter.documentation.value
   end
 
   -- test markdown hl

--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -259,7 +259,7 @@ helper.match_parameter = function(result, config)
   end
   if nextParameter.documentation and #nextParameter.documentation > 0 then
     nexp = nexp .. ': ' .. nextParameter.documentation
-  elseif nextParameter.documentation.value and #nextParameter.documentation.value > 0 then -- this is to follow when the documentation is a table like {kind= xxx, value= zzz}
+  elseif type(nextParameter.documentation) == 'table' and nextParameter.documentation.value then -- this is to follow when the documentation is a table like {kind= xxx, value= zzz}
     nexp = nexp .. ': ' .. nextParameter.documentation.value
   end
 


### PR DESCRIPTION
This fix deals with an annoyance that the hint wasn't appearing when using the Roslyn lsp.

This is what the LSP sends to neovim:

```
 { "signatures" =  { "documentation" = { "kind" = "plaintext", "value" = "the center of a circle"}, "label" = "center"}
```

This is how it was being rendered before the change:
![image](https://github.com/user-attachments/assets/95358f2e-6517-4b00-b3eb-958c84d3b4dd)

This is how it is being rendered after the change:
![image](https://github.com/user-attachments/assets/8e79bc3e-9ec6-4d4b-8316-b4d756c14bd0)

I have tested with the lua_ls, omnisharp and Roslyn, everything seems to be working fine