### PR TITLE
fix: incorrect calculation of character index

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -733,7 +733,7 @@ local signature = function(opts)
     end
   end
 
-  local shift = math.max(1, trigger_position - 0)
+  local shift = math.max(0, trigger_position - 0)
   local params = helper.make_position_params({
     position = {
       character = shift,


### PR DESCRIPTION
I periodically started getting errors from tsserver, as shown in the screenshot. After some debugging, I found that an error occurs when the cursor is on an empty line(with line feed only) and the character number in the query is 1, although it should be 0 as far as I understand. After this correction, the errors disappeared.
![Screenshot_2025-04-21_20-00-34](https://github.com/user-attachments/assets/f3ac33d1-6263-4f94-a9ad-ac99e290d796)
