### PR TITLE
fix character index calculation considering LSP offset encoding

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -733,7 +733,7 @@ local signature = function(opts)
     end
   end
 
-  local shift = math.max(1, trigger_position - 0)
+  local shift = math.max(0, trigger_position - 0)
   local params = helper.make_position_params({
     position = {
       character = shift,


### PR DESCRIPTION
Currently, the shift is calculated based on the number of bytes in the lua string, which is incorrect. This fix calculates the index based on the LSP offset encoding.