### PR TITLE
Fix handling false which is returned by hint_inline function

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -150,8 +150,12 @@ local function virtual_hint(hint, off_y)
     or '🐼 '
 
   if off_y and off_y ~= 0 then
-    local inline = type(_LSP_SIG_CFG.hint_inline) == 'function' and _LSP_SIG_CFG.hint_inline() == 'inline'
-      or _LSP_SIG_CFG.hint_inline
+    local inline
+    if type(_LSP_SIG_CFG.hint_inline) == 'function' then
+      inline = vim.tbl_contains({ 'inline', 'eol', 'right_align' }, _LSP_SIG_CFG.hint_inline())
+    else
+      inline = _LSP_SIG_CFG.hint_inline
+    end
     -- stay out of the way of the pum
     if completion_visible or inline then
       show_at = cur_line


### PR DESCRIPTION
### Overview
The lsp_signature displays hint in the same line also if specify function which will return false to disable inline hint.

### Cause
`_LSP_SIG_CFG.hint_inline` is function and it is evaluated as truthy value.

### Options
```lua
opts = {
  hint_inline = function() return false end,  -- default
  hint_prefix = {
    above = "↙ ",
    current = "←  ",
    below = "↖ "
  },
}
```

### Expected behavior ( or patched version behavior)
![image](https://github.com/user-attachments/assets/c59da9e9-b815-450e-8a4f-890cddab035a)

### Actual behavior
![image](https://github.com/user-attachments/assets/ec33d844-4ec1-4fb6-af2f-aca99ba1f216)
