### PR TITLE
Make ignore error callback work in signature_should_close_handler

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -1038,9 +1038,11 @@ M.on_attach = function(cfg, bufnr)
   _LSP_SIG_VT_NS = api.nvim_create_namespace('lsp_signature_vt')
 end
 
-local signature_should_close_handler = function(err, result, ctx, _)
+local signature_should_close_handler = function(err, result, ctx, config)
   if err ~= nil then
-    print(err)
+    if not _LSP_SIG_CFG.ignore_error(err, ctx, config) then
+      print(err)
+    end
     helper.cleanup_async(true, 0.01, true)
     status_line = { hint = '', label = '' }
     return


### PR DESCRIPTION
This [commit](https://github.com/ray-x/lsp_signature.nvim/commit/0f6b01b83169b2dace5d7593110755fce3d38218) introduced an ignore_error callback that can be specified in the plugin's config to ignore certain errors, as a fix to #168.
I installed `ocamllsp` and noticed that I kept getting these errors despite ignoring them in the config. It turns out that `signature_should_close_handler` can also print an error, but isn't configured to work with the ignore_error callback. This PR fixes that issue.