### PR TITLE
docs: add ignore_error example comments for content modified

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -53,6 +53,8 @@ _LSP_SIG_CFG = {
     -- other examples:
     -- if err.code_name == 'InvalidParams' then return true end
     -- if err.code_name == 'ContentModified' then return true end
+    -- if err.code == -32801 then return true end
+    -- if err.message == 'content modified' then return true end
   end,
   floating_window_above_cur_line = true,          -- try to place the floating above the current line
   toggle_key_flip_floatwin_setting = false,       -- toggle key will enable|disable floating_window flag


### PR DESCRIPTION
Adding these example comments because the `code_name` example did not work for my rust-analyzer setup which returned this as `err`:
```
{
  code = -32801,
  message = "content modified",
  <metatable> = {
    __tostring = <function 1>
  }
}
```
which does not have `code_name`
