### PR TITLE
Fix exception in Nvim 0.12.0

### DIFF
--- a/lua/lsp_signature/helper.lua
+++ b/lua/lsp_signature/helper.lua
@@ -212,7 +212,7 @@ helper.match_parameter = function(result, config)
 
   local activeParameter = signature.activeParameter or result.activeParameter
 
-  if activeParameter == nil or activeParameter < 0 then
+  if type(activeParameter) ~= 'number' or activeParameter < 0 then
     log('incorrect signature response?', result, config)
     activeParameter = helper.fallback(config.triggered_chars or { '(', ',' })
   end
@@ -227,7 +227,7 @@ helper.match_parameter = function(result, config)
     return result, '', 0, 0
   end
 
-  if activeParameter > #signature.parameters then
+  if type(activeParameter) ~= 'number' or activeParameter > #signature.parameters then
     activeParameter = 0
   end
 

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -634,10 +634,11 @@ local signature_handler = function(err, result, ctx, config)
   local sig = result.signatures
   -- if it is last parameter, close windows after cursor moved
 
-  local actPar = sig.activeParameter or result.activeParameter or 0
+  local actPar = (type(sig.activeParameter) == 'number' and sig.activeParameter)
+    or (type(result.activeParameter) == 'number' and result.activeParameter)
+    or 0
   if
     sig and sig[activeSignature].parameters == nil
-    or actPar == nil
     or actPar + 1 == #sig[activeSignature].parameters
   then
     log('last para', close_events)

--- a/tests/signature_spec.lua
+++ b/tests/signature_spec.lua
@@ -226,6 +226,22 @@ describe('should show signature ', function()
     eq(40, e)
   end)
 
+  it('match should not crash when activeParameter is vim.NIL (Nvim 0.12 null)', function()
+    local result1 = vim.deepcopy(result)
+    result1.activeParameter = vim.NIL
+    -- Should not raise an error; falls back to position 0 (first parameter)
+    local ok, err = pcall(match_parameter, result1, cfg)
+    assert.is_true(ok, 'match_parameter crashed with vim.NIL: ' .. tostring(err))
+  end)
+
+  it('match should not crash when signature.activeParameter is vim.NIL', function()
+    local result1 = vim.deepcopy(result)
+    result1.activeParameter = 0
+    result1.signatures[1].activeParameter = vim.NIL
+    local ok, err = pcall(match_parameter, result1, cfg)
+    assert.is_true(ok, 'match_parameter crashed with vim.NIL on signature: ' .. tostring(err))
+  end)
+
   it('match should get signature for ccls multi ', function()
     local result1 = vim.deepcopy(result_ccls)
     result1.activeParameter = 1
@@ -443,5 +459,44 @@ describe('should show signature ', function()
     end
 
     eq('HandleFunc(path string, f func(http.ResponseWriter,  *http.Request)) *mux.Route', lines[2])
+  end)
+
+  it('should not crash when sig.activeParameter is vim.NIL (init.lua:641)', function()
+    _LSP_SIG_CFG.debug = false
+    _LSP_SIG_CFG.floating_window = true
+
+    local r = {
+      activeParameter = vim.NIL,
+      activeSignature = 0,
+      signatures = {
+        {
+          activeParameter = vim.NIL,
+          label = 'fn add(left: i32, right: i32) -> i32',
+          parameters = { { label = { 7, 16 } }, { label = { 18, 28 } } },
+        },
+      },
+    }
+
+    local c = {
+      check_completion_visible = true,
+      check_client_handlers = true,
+      trigger_from_lsp_sig = true,
+      line_to_cursor = '    add(1, ',
+      triggered_chars = { '(', ',' },
+    }
+
+    local ctx = {
+      method = 'textDocument/signatureHelp',
+      client_id = 1,
+      bufnr = vim.api.nvim_get_current_buf(),
+    }
+
+    local ok, err
+    if nvim_6 then
+      ok, err = pcall(signature.signature_handler, nil, r, ctx, c)
+    else
+      ok, err = pcall(signature.signature_handler, nil, '', r, 1, 1, c)
+    end
+    assert.is_true(ok, 'signature_handler crashed with vim.NIL activeParameter: ' .. tostring(err))
   end)
 end)


### PR DESCRIPTION
Fix #381 
In Nvim 0.12.0, JSON null values in LSP responses surface as vim.NIL — a userdata sentinel — rather than Lua nil. The two values are distinct: vim.NIL == nil is false.

helper.match_parameter() reads activeParameter from the LSP SignatureHelp response and used two comparisons that assumed the value was either nil or a number:

Three new cases in tests/signature_spec.lua verify the fix against vim.NIL directly