### PR TITLE
Fix vim.NIL exception

### DIFF
--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -806,7 +806,8 @@ local signature = function(opts)
     if _LSP_SIG_CFG.signature_result and _LSP_SIG_CFG.signature_result.signatures ~= nil then
       local sig = _LSP_SIG_CFG.signature_result.signatures
       local actSig = _LSP_SIG_CFG.signature_result.activeSignature or 0
-      local actPar = _LSP_SIG_CFG.signature_result.activeParameter or 0
+      local actPar = (type(_LSP_SIG_CFG.signature_result.activeParameter) == 'number' and _LSP_SIG_CFG.signature_result.activeParameter)
+        or 0
       actSig, actPar = actSig + 1, actPar + 1
       if sig[actSig] ~= nil and sig[actSig].parameters ~= nil and #sig[actSig].parameters == actPar then
         M.on_CompleteDone()

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -364,7 +364,9 @@ local signature_handler = function(err, result, ctx, config)
     for i = #result.signatures, 1, -1 do
       local sig = result.signatures[i]
       -- hack for lua
-      local actPar = sig.activeParameter or result.activeParameter or 0
+      local actPar = (type(sig.activeParameter) == 'number' and sig.activeParameter)
+        or (type(result.activeParameter) == 'number' and result.activeParameter)
+        or 0
       if actPar > 0 and actPar + 1 > #(sig.parameters or {}) then
         log('invalid lsp response, active parameter out of boundary')
         -- reset active parameter to last parameter

--- a/lua/lsp_signature/init.lua
+++ b/lua/lsp_signature/init.lua
@@ -806,8 +806,10 @@ local signature = function(opts)
     if _LSP_SIG_CFG.signature_result and _LSP_SIG_CFG.signature_result.signatures ~= nil then
       local sig = _LSP_SIG_CFG.signature_result.signatures
       local actSig = _LSP_SIG_CFG.signature_result.activeSignature or 0
-      local actPar = (type(_LSP_SIG_CFG.signature_result.activeParameter) == 'number' and _LSP_SIG_CFG.signature_result.activeParameter)
-        or 0
+      local actPar = (
+        type(_LSP_SIG_CFG.signature_result.activeParameter) == 'number'
+        and _LSP_SIG_CFG.signature_result.activeParameter
+      ) or 0
       actSig, actPar = actSig + 1, actPar + 1
       if sig[actSig] ~= nil and sig[actSig].parameters ~= nil and #sig[actSig].parameters == actPar then
         M.on_CompleteDone()


### PR DESCRIPTION
Related #382 
I encountered an exception that doesn't seem to be handled in the previous fix.

```
vim.schedule callback: .../nvim/lazy/lsp_signature.nvim/lua/lsp_signature/init.lua:368: attempt to compare number with userdata
stack traceback:
        .../nvim/lazy/lsp_signature.nvim/lua/lsp_signature/init.lua:368: in function 'handler'
        /usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:758: in function 'fn'
        [string "vim/_core/editor"]:404: in function <[string "vim/_core/editor"]:403>
```

This PR fixes this exception.
